### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,8 +1,28 @@
-import { component$ } from '@builder.io/qwik';
+import { $, component$, useStore, useVisibleTask$ } from '@builder.io/qwik';
 import { Dropdown, Navbar } from 'flowbite-qwik';
 import { Link } from '@builder.io/qwik-city';
 
 export default component$(() => {
+  const theme = useStore({ mode: 'light' });
+
+  useVisibleTask$(() => {
+    const saved = localStorage.getItem('theme');
+    theme.mode =
+      saved ??
+      (window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light');
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.classList.add(theme.mode);
+  });
+
+  const toggleTheme = $(() => {
+    theme.mode = theme.mode === 'dark' ? 'light' : 'dark';
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.classList.add(theme.mode);
+    localStorage.setItem('theme', theme.mode);
+  });
+
   return (
     <Navbar fluid class="fixed top-0 w-full z-50 bg-black/70 backdrop-blur-md border-b border-gray-700">
       <Navbar.Brand tag={Link} href="/">
@@ -17,15 +37,15 @@ export default component$(() => {
       </Navbar.Brand>
 
       <div class="flex items-center md:order-2">
-        <Dropdown
-          as={
-            <img
-              class="h-8 w-8 rounded-full ring-2 ring-gray-600"
-              src="https://res.cloudinary.com/dkht4mwqi/image/upload/f_auto,q_auto/v1718462568/flowbite-qwik/jpnykkz8ojq7ojgg4qta.jpg"
-              alt="user photo"
-            />
-          }
-        >
+          <Dropdown
+            as={
+              <img
+                class="h-8 w-8 rounded-full ring-2 ring-gray-600"
+                src="https://res.cloudinary.com/dkht4mwqi/image/upload/f_auto,q_auto/v1718462568/flowbite-qwik/jpnykkz8ojq7ojgg4qta.jpg"
+                alt="user photo"
+              />
+            }
+          >
           <Dropdown.Item header>
             <span class="block text-sm font-medium">Bonnie Green</span>
             <span class="block text-xs text-gray-400">name@flowbite.com</span>
@@ -36,6 +56,12 @@ export default component$(() => {
           <Dropdown.Item divider />
           <Dropdown.Item>Sign out</Dropdown.Item>
         </Dropdown>
+        <button
+          onClick$={toggleTheme}
+          class="mx-2 text-sm text-gray-300 hover:text-yellow-300 transition"
+        >
+          {theme.mode === 'dark' ? 'Light' : 'Dark'}
+        </button>
         <Navbar.Toggle />
       </div>
 

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -27,8 +27,8 @@ export default component$(() => {
         <FlowbiteProviderHeader />
         <RouterHead />
       </head>
-      <body lang="en">
-        <FlowbiteProvider theme="yellow" toastPosition="top-right">
+      <body lang="en" class="light">
+        <FlowbiteProvider theme={'yellow' as any} toastPosition="top-right">
           <RouterOutlet />
         </FlowbiteProvider>
       </body>


### PR DESCRIPTION
## Summary
- enable light mode by default and cast Flowbite theme
- add a client-side theme toggle to the navbar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895ca91b9c8833280faf80979659760